### PR TITLE
fix URL to IRC channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ Sincerely,
 
 MY_NAME</p></pre>
 
-<p>After you've emailed us, you may also wish to <a href="http://lists.openhatch.org/mailman/listinfo/osctc-planning">join the Open Source Comes to Campus mailing list</a>. You may also wish to <a href="https://twitter.com/openhatch">follow OpenHatch on Twitter</a> or <a href="https://openhatch/contact/">join the OpenHatch IRC channel</a>.</p>
+<p>After you've emailed us, you may also wish to <a href="http://lists.openhatch.org/mailman/listinfo/osctc-planning">join the Open Source Comes to Campus mailing list</a>. You may also wish to <a href="https://twitter.com/openhatch">follow OpenHatch on Twitter</a> or <a href="http://openhatch.readthedocs.org/en/latest/community/contact.html">join the OpenHatch IRC channel</a>.</p>
 </div>
 </div>
 


### PR DESCRIPTION
Made the url (1) correctly formed and (2) consistent with the IRC URL presented to the user on https://openhatch.org/wiki/Main_Page (goes to a page with instructions on IRC via web or app).
